### PR TITLE
Updating Resette URLs and Datasette version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,7 @@
   "license": "ODbL",
   "license_url": "https://opendatacommons.org/licenses/odbl/",
   "source": "EDGI Cloud Portal",
-  "source_url": "https://edgi-cloud.fly.dev/",
+  "source_url": "https://resette.envirodatagov.org",
   "databases": {},
   "plugins": {
     "datasette-cluster-map": {

--- a/plugins/generate_metadata.py
+++ b/plugins/generate_metadata.py
@@ -26,7 +26,7 @@ def generate_metadata():
         "license": "ODbL",
         "license_url": "https://opendatacommons.org/licenses/odbl/",
         "source": "EDGI Cloud Portal",
-        "source_url": "https://edgi-cloud.fly.dev/",
+        "source_url": "https://resette.envirodatagov.org",
         "databases": {},
         "plugins": {
             "datasette-cluster-map": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core Datasette
-datasette==0.65.1
+datasette==0.65.2
 sqlite-utils>=3.35
 markupsafe==2.1.5
 gunicorn==22.0.0


### PR DESCRIPTION
Updating requirements.txt to upgrade Datasette version. Updating metadata.json and plugins/generate_metadata.py to change hardcoded url to resette.envirodatagov.org