### PR TITLE
Fix URL redirect bug + add test suite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN echo '#!/bin/bash\n\
   --template-dir templates \\\n\
   --static static:static \\\n\
   --plugins-dir plugins \\\n\
+  --setting base_url "${APP_URL:-https://resette.envirodatagov.org}/" \\\n\
   --setting max_returned_rows 3000000 \\\n\
   --setting sql_time_limit_ms 360000 \\\n\
   --setting allow_download on \\\n\

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY plugins/ ./plugins/
+COPY templates/ ./templates/
+COPY static/ ./static/
+COPY tests/ ./tests/
+COPY pytest.ini .
+COPY init_db.py .
+COPY migrate_db.py .
+COPY metadata.json .
+
+CMD ["pytest", "--tb=short", "-v"]

--- a/README.md
+++ b/README.md
@@ -343,6 +343,24 @@ APP_URL=https://your-domain.fly.dev
 - `trash_retention_days` - Recovery period
 - `allowed_extensions` - Permitted file types
 
+## 🧪 Testing
+
+### Run tests with Docker (recommended)
+
+```bash
+docker build -f Dockerfile.test -t edgi-test .
+docker run --rm edgi-test
+```
+
+### Run tests locally
+
+Ensure dependencies are installed, then:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
 ## 🤝 Contributing
 
 We welcome contributions! Please:

--- a/migrate_db.py
+++ b/migrate_db.py
@@ -165,7 +165,7 @@ def migrate_database():
         else:
             print("Creating databases table...")
             db.executescript("""
-                CREATE TABLE databases (
+                CREATE TABLE IF NOT EXISTS databases (
                     db_id TEXT PRIMARY KEY,
                     user_id TEXT,
                     db_name TEXT,
@@ -354,7 +354,36 @@ def migrate_database():
         else:
             print("   markdown_columns structure verified")
 
-        # 8. Database statistics
+        # 8. Correct frozen website_url values that point to the wrong host
+        app_url = os.getenv('APP_URL', '').rstrip('/')
+        current_tables = [t.name for t in db.tables]
+        if app_url and 'databases' in current_tables:
+            print("Checking for website_url values with incorrect host...")
+            from urllib.parse import urlparse
+            canonical_host = urlparse(app_url).netloc
+            rows = db.execute(
+                "SELECT db_id, db_name, website_url FROM databases WHERE website_url IS NOT NULL"
+            ).fetchall()
+            fixed_count = 0
+            for db_id, db_name, website_url in rows:
+                parsed = urlparse(website_url)
+                if parsed.netloc and parsed.netloc != canonical_host:
+                    corrected = f"{app_url}/db/{db_name}/homepage"
+                    db.execute(
+                        "UPDATE databases SET website_url = ? WHERE db_id = ?",
+                        [corrected, db_id]
+                    )
+                    fixed_count += 1
+                    print(f"   Fixed: {website_url} -> {corrected}")
+            if fixed_count:
+                db.conn.commit()
+                print(f"   Corrected {fixed_count} website_url value(s)")
+            else:
+                print("   All website_url values are already correct")
+        else:
+            print("   Skipping website_url correction (APP_URL not set)")
+
+        # 9. Database statistics
         print("Database statistics:")
         try:
             users_count = db.execute("SELECT COUNT(*) FROM users").fetchone()[0]

--- a/plugins/common_utils.py
+++ b/plugins/common_utils.py
@@ -1049,14 +1049,22 @@ async def redirect_authenticated_user(actor):
 def generate_website_url(request, db_name):
     """
     Generate a full website URL for a database homepage.
-    
+
+    Uses the APP_URL environment variable as the base when set, so the stored
+    URL always reflects the canonical public domain rather than whatever host
+    header the creator happened to use (e.g. edgi-cloud.fly.dev). Falls back
+    to deriving scheme + host from the request for local development.
+
     Args:
         request: HTTP request object
         db_name (str): Database name
-        
+
     Returns:
         str: Full URL to database homepage
     """
+    app_url = os.getenv('APP_URL', '').rstrip('/')
+    if app_url:
+        return f"{app_url}/db/{db_name}/homepage"
     scheme = request.scheme
     host = request.headers.get('host', 'localhost:8001')
     return f"{scheme}://{host}/db/{db_name}/homepage"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,7 @@ markdown>=3.4.0
 email-validator>=1.3.0   # Email validation
 python-dateutil>=2.8.0   # Date parsing utilities
 httpx
+
+# Testing
+pytest>=8.0.0
+pytest-asyncio>=0.23.0

--- a/tests/test_generate_website_url.py
+++ b/tests/test_generate_website_url.py
@@ -1,0 +1,44 @@
+"""
+Unit tests for generate_website_url() in plugins/common_utils.py.
+
+Verifies that:
+- APP_URL env var is used as the base when set
+- Falls back to request-derived host when APP_URL is unset
+- Trailing slashes on APP_URL do not produce double slashes in the output
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "plugins"))
+
+from common_utils import generate_website_url
+
+
+class MockRequest:
+    """Minimal request stand-in with the attributes generate_website_url reads."""
+
+    def __init__(self, scheme="http", host="localhost:8001"):
+        self.scheme = scheme
+        self.headers = {"host": host}
+
+
+def test_uses_app_url_when_set(monkeypatch):
+    monkeypatch.setenv("APP_URL", "https://resette.envirodatagov.org")
+    request = MockRequest()
+    result = generate_website_url(request, "my_db")
+    assert result == "https://resette.envirodatagov.org/db/my_db/homepage"
+
+
+def test_falls_back_to_request_host_when_app_url_unset(monkeypatch):
+    monkeypatch.delenv("APP_URL", raising=False)
+    request = MockRequest(scheme="http", host="localhost:8001")
+    result = generate_website_url(request, "my_db")
+    assert result == "http://localhost:8001/db/my_db/homepage"
+
+
+def test_app_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.setenv("APP_URL", "https://resette.envirodatagov.org/")
+    request = MockRequest()
+    result = generate_website_url(request, "my_db")
+    assert "//" not in result.replace("https://", "").replace("http://", "")
+    assert result == "https://resette.envirodatagov.org/db/my_db/homepage"

--- a/tests/test_migrate_url_correction.py
+++ b/tests/test_migrate_url_correction.py
@@ -1,0 +1,76 @@
+"""
+Unit tests for the website_url correction step in migrate_db.migrate_database().
+
+Verifies that:
+- Rows with a wrong host are rewritten to use the APP_URL canonical host
+- Rows already using the correct host are left unchanged
+- Running migrate_database() twice produces the same result (idempotent)
+"""
+import sys
+import os
+import sqlite3
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import migrate_db
+
+
+CANONICAL_URL = "https://resette.envirodatagov.org"
+BAD_URL = "http://edgi-cloud.fly.dev/db/foo/homepage"
+GOOD_URL = f"{CANONICAL_URL}/db/foo/homepage"
+
+
+def _insert_db_row(db_path, db_id, db_name, website_url):
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """INSERT INTO databases
+           (db_id, user_id, db_name, website_url, status, created_at, updated_at)
+           VALUES (?, 'user1', ?, ?, 'Published', '2025-01-01', '2025-01-01')""",
+        [db_id, db_name, website_url],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_website_url(db_path, db_id):
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT website_url FROM databases WHERE db_id = ?", [db_id]
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+@pytest.fixture()
+def initialized_db(tmp_path, monkeypatch):
+    """Return the path to a temp portal.db with schema created by migrate_database()."""
+    db_path = str(tmp_path / "portal.db")
+    monkeypatch.setenv("PORTAL_DB_PATH", db_path)
+    monkeypatch.setenv("APP_URL", CANONICAL_URL)
+    monkeypatch.setattr(migrate_db, "PORTAL_DB_PATH", db_path)
+    migrate_db.migrate_database()
+    return db_path
+
+
+def test_corrects_wrong_host(initialized_db, monkeypatch):
+    _insert_db_row(initialized_db, "id1", "foo", BAD_URL)
+    monkeypatch.setattr(migrate_db, "PORTAL_DB_PATH", initialized_db)
+    migrate_db.migrate_database()
+    assert _read_website_url(initialized_db, "id1") == GOOD_URL
+
+
+def test_skips_correct_host(initialized_db, monkeypatch):
+    _insert_db_row(initialized_db, "id2", "foo", GOOD_URL)
+    monkeypatch.setattr(migrate_db, "PORTAL_DB_PATH", initialized_db)
+    migrate_db.migrate_database()
+    assert _read_website_url(initialized_db, "id2") == GOOD_URL
+
+
+def test_idempotent(initialized_db, monkeypatch):
+    _insert_db_row(initialized_db, "id3", "foo", BAD_URL)
+    monkeypatch.setattr(migrate_db, "PORTAL_DB_PATH", initialized_db)
+    migrate_db.migrate_database()
+    migrate_db.migrate_database()
+    assert _read_website_url(initialized_db, "id3") == GOOD_URL

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,47 @@
+"""
+Smoke test: Datasette starts with all plugins loaded and the homepage returns 200.
+
+Catches plugin import errors and startup crashes without requiring a live server.
+Uses a fresh portal.db created by migrate_database() so no external state is needed.
+"""
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import migrate_db
+
+REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+
+
+@pytest.fixture()
+def portal_db(tmp_path, monkeypatch):
+    """Create a minimal initialized portal.db in a temp directory."""
+    db_path = str(tmp_path / "portal.db")
+    monkeypatch.setenv("PORTAL_DB_PATH", db_path)
+    monkeypatch.setenv("APP_URL", "https://resette.envirodatagov.org")
+    monkeypatch.setenv("RESETTE_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("RESETTE_STATIC_DIR", os.path.join(REPO_ROOT, "static"))
+    monkeypatch.setattr(migrate_db, "PORTAL_DB_PATH", db_path)
+    migrate_db.migrate_database()
+    import sqlite_utils
+    import init_db
+    db = sqlite_utils.Database(db_path)
+    init_db.create_database_schema(db)
+    init_db.create_portal_content(db)
+    return db_path
+
+
+async def test_homepage_ok(portal_db):
+    from datasette.app import Datasette
+
+    ds = Datasette(
+        files=[portal_db],
+        plugins_dir=os.path.join(REPO_ROOT, "plugins"),
+        template_dir=os.path.join(REPO_ROOT, "templates"),
+        metadata={"databases": {}},
+    )
+    response = await ds.client.get("/")
+    assert response.status_code == 200


### PR DESCRIPTION
# What was broken

Databases created via edgi-cloud.fly.dev had that hostname permanently baked into their stored URL. Links on the portal homepage would then send users to the fly.dev domain instead of resette.envirodatagov.org, which made it impossible to put the app behind a CDN or rate limiter.

APP_URL was already set in fly.toml — it just wasn't being used.

# What changed

- generate_website_url() now reads APP_URL instead of copying the request's Host header. Falls back to the old behaviour when APP_URL is unset, so local dev still works.
- migrate_db.py now corrects any already-stored bad URLs on startup.
- Dockerfile passes --setting base_url to Datasette so its own internal links also use the right domain.
- Two pre-existing bugs in migrate_db.py were fixed along the way: a missing IF NOT EXISTS on a CREATE TABLE that caused crashes on the second run, and a stale table-list snapshot that caused a URL correction step to silently skip.

## Tests
There were no tests before this PR. There are now 7, covering:

- generate_website_url() with and without APP_URL set
- The migration URL-correction step (including idempotency)
- A smoke test that starts Datasette with all plugins and checks the homepage returns 200


## New Test

```bash
docker build -f Dockerfile.test -t edgi-test .
docker run --rm edgi-test
```
or
```bash
pip install -r requirements.txt
pytest
```